### PR TITLE
feat: add tenant_id claim to JWT tokens for multi-tenancy

### DIFF
--- a/src/jwt/tenantClaims.ts
+++ b/src/jwt/tenantClaims.ts
@@ -1,0 +1,7 @@
+export function addTenantClaim(payload: JWTPayload, tenantId: string): JWTPayload {
+  return { ...payload, tenant_id: tenantId };
+}
+
+export function extractTenant(token: DecodedJWT): string {
+  return token.tenant_id || "default";
+}


### PR DESCRIPTION
## Summary
Adds tenant_id to JWT claims for the multi-tenancy migration.

## Changes
- Add tenant_id to token generation
- Extract tenant_id in token verification
- Backward compatible: tokens without tenant_id default to 'default' tenant

## Related
- Resolves #8
- API migration: afcrichmond-labs/richmond-api PR (multi-tenant)
- **Linear:** RIC-207